### PR TITLE
Fix dependecies from zendserver with libmysqlclient18

### DIFF
--- a/8.5/5.6/Dockerfile
+++ b/8.5/5.6/Dockerfile
@@ -6,10 +6,11 @@ FROM ubuntu:16.04
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key 799058698E65316A2E7A4FF42EAE1437F7D2C623
 COPY zs8_5-apache2_4.list /etc/apt/sources.list.d/zend-server.list
+COPY ubuntu-trusty.list /etc/apt/sources.list.d/ubuntu-trusty.list
 RUN apt-get update \
     && apt-get install -y \
         curl \
-        libmysqlclient20 \
+        libmysqlclient18 \
         unzip \
         git \
         zend-server-php-5.6=8.5.15+b8 \

--- a/8.5/5.6/ubuntu-trusty.list
+++ b/8.5/5.6/ubuntu-trusty.list
@@ -1,0 +1,3 @@
+### Repositories from ubuntu trusty 14.04.
+deb http://br.archive.ubuntu.com/ubuntu/ trusty main restricted universe multiverse
+deb-src http://br.archive.ubuntu.com/ubuntu/ trusty main restricted universe multiverse


### PR DESCRIPTION
I had problems starting a container from the php-zendserver: 8.5 image related to libmysqlclient18 a dependency on zendzerver is not installed and does not exist in the ubuntu 16.04 repositories.

I added support for ubuntu trusty repositories (14.04) to install libmysqlclient18 directly on the image.

Reported problem at this issue: https://github.com/zendtech/php-zendserver-docker/issues/16