### PR TITLE
Fix: PGP server is unreachable in the Firewalled Network

### DIFF
--- a/2019.0/Dockerfile
+++ b/2019.0/Dockerfile
@@ -7,7 +7,7 @@ FROM ubuntu:18.04
 RUN apt-get update && apt-get install -y \
       gnupg
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key 799058698E65316A2E7A4FF42EAE1437F7D2C623
+RUN apt-key adv --fetch-keys http://repos.zend.com/zend.key
 COPY zs2019_0-ssl1.1.list /etc/apt/sources.list.d/zend-server.list
 RUN apt-get update && apt-get install -y \
       iproute2 \


### PR DESCRIPTION
The build process for Zend Server 2019 fails on corporate networks protected by firewalls.

From restricted networks it is impossible to import PGP keys.

The proposed fix is ​​based on: https://help.zend.com/zend/current/content/deb_installing_zend_server.htm
