### PR TITLE
Fix for error when 'ZS_PROFILE' is set to development.

### DIFF
--- a/ZS/run.sh
+++ b/ZS/run.sh
@@ -90,8 +90,8 @@ if [ ! -s /var/zs-xchange/web_api_secret ]; then
 	# the below only makes sense in the first node or single server
 	if [[ $ZS_PROFILE =~ ^dev(elopment)*$|^DEV(ELOPMENT)*$ ]]; then
 		echo "Changing server profile to 'development':" >> /tmp/metalog.log
-		/usr/local/bin/zs-client.phar setServerProfile --production=false --output-format=kv --zskey=docker --zssecret=$WEB_API_SECRET >> /tmp/metalog.log 2>&1
-		/usr/local/bin/zs-client.phar restartPhp --output-format=kv --zskey=docker --zssecret=$WEB_API_SECRET >> /tmp/metalog.log 2>&1
+		/usr/local/zend/bin/php /usr/local/bin/zs-client.phar setServerProfile --production=false --output-format=kv --zskey=docker --zssecret=$WEB_API_SECRET >> /tmp/metalog.log 2>&1
+		/usr/local/zend/bin/php /usr/local/bin/zs-client.phar restartPhp --output-format=kv --zskey=docker --zssecret=$WEB_API_SECRET >> /tmp/metalog.log 2>&1
 	fi
 fi
 


### PR DESCRIPTION
The PR fixes the following errors:
```
Changing server profile to 'development':
/usr/local/bin/run.sh: /usr/local/bin/zs-client.phar: /usr/bin/env: bad interpreter: Permission denied
/usr/local/bin/run.sh: /usr/local/bin/zs-client.phar: /usr/bin/env: bad interpreter: Permission denied
```

The errors occur when ZS_PROFILE is set to 'development' and are due to the fact the 'zs-client.phar' file is executed without the PHP interpreter.