### PR TITLE
chore: reduce attack surface and size for Docker image

### DIFF
--- a/2021.0/Dockerfile
+++ b/2021.0/Dockerfile
@@ -4,12 +4,12 @@
 
 FROM ubuntu:18.04
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       gnupg
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-key 799058698E65316A2E7A4FF42EAE1437F7D2C623
 COPY zend-server.list /etc/apt/sources.list.d/zend-server.list
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
       iproute2 \
       curl \
       libmysqlclient20 \


### PR DESCRIPTION
Hi,

This pull request includes several small improvements for the Dockerfile, which should help improve the security of container and reduce the risk of potential attacks.

The following changes have been made:
- I added `--no-install-recommends` to remove unnecessary `apt` packages, that were not needed for the container's functionality. Not only can this change trim your image size but it also can also reduce the attack surface.

I hope that you find them useful. Please let me know if you have any concerns.

Thank you.